### PR TITLE
Specify `tslib` as dependency instead of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "ts-jest": "^25.4.0",
     "ts-node": "^8.9.1",
     "tsconfig-paths": "^3.9.0",
-    "tslib": "^1.11.1",
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "axios": "^0.21.1"
+    "axios": "^0.21.1",
+    "tslib": "^1.11.1"
   }
 }


### PR DESCRIPTION
This is required by https://github.com/FreeTubeApp/FreeTube/pull/1723
To fix the "built app not starting up" issue like https://github.com/FreeTubeApp/FreeTube/issues/1722