### PR TITLE
+ Add .editorconfig file like FreeTube app repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
You can see the main app repo has [a file named `.editorconfig`](https://github.com/FreeTubeApp/FreeTube/blob/development/.editorconfig) already.

To find out its purposes see https://editorconfig.org